### PR TITLE
Fix and update CI stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,10 @@
 # These lines impact repository security
-/.github/CODEOWNERS        @jcape
-/.github/settings.yml      @jcape
+
+/.github/CODEOWNERS        @jcape @varsha888
+/.github/settings.yml      @jcape @varsha888
 
 # These lines prevent reviews of trivial changes blocking on particular users
+
 /.gitattributes
 /.gitconfig
 /.gitignore
@@ -15,3 +17,5 @@
 /deny.toml
 /rust-toolchain.toml
 /rustfmt.toml
+
+/src/                      @jcape @varsha888

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -2,4 +2,4 @@
 addReviewers: true
 addAssignees: author
 reviewers:
-  - mobilecoinfoundation/coredev
+  - "@mobilecoinfoundation/coredev"

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,2 +1,5 @@
 ---
+addReviewers: true
 addAssignees: author
+reviewers:
+  - "@mobilecoinfoundation/coredev"

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,2 +1,5 @@
 ---
+addReviewers: true
 addAssignees: author
+reviewers:
+  - "mobilecoinfoundation/coredev"

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,5 +1,2 @@
 ---
-addReviewers: true
 addAssignees: author
-reviewers:
-  - "mobilecoinfoundation/coredev"

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -2,4 +2,4 @@
 addReviewers: true
 addAssignees: author
 reviewers:
-  - "@mobilecoinfoundation/coredev"
+  - "mobilecoinfoundation/coredev"

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,5 +1,2 @@
 ---
-addReviewers: true
 addAssignees: author
-reviewers:
-  - "@mobilecoinfoundation/coredev"

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -11,3 +11,4 @@ github_actions:
   - '.github/workflows/**'
   - '.github/labeler.yaml'
   - '.github/triage-labeler.yaml'
+  - '.github/auto_assign.yaml'

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -4,9 +4,6 @@ rust:
   - '**/Cargo.lock'
   - '**/Cargo.toml'
 
-dependencies:
-  - '**/Cargo.lock'
-
 github_actions:
   - '.github/workflows/**'
   - '.github/labeler.yaml'

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -78,9 +78,7 @@ branches:
       required_status_checks:
         strict: false
         contexts:
-          - rustfmt
-          - markdown-lint
-          - yamllint
+          - lint
           - "deny (bans licenses sources)"
           - sort
           - "clippy (stable)"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -56,7 +56,9 @@ labels:
     description: PRs that should get broken down
 
 collaborators:
-  - username: nick-mobilecoin
+  - username: varsha888
+    permission: maintain
+  - username: jcape
     permission: maintain
 
 teams:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -56,6 +56,8 @@ labels:
     description: PRs that should get broken down
 
 collaborators:
+  - username: meowblecoinbot
+    permission: triage
   - username: varsha888
     permission: maintain
   - username: jcape

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   # TODO: Fix automatically
-  rustfmt:
+  lint:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -23,30 +23,16 @@ jobs:
           components: rustfmt
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo fmt --all -- --check
-
-  # TODO: Fix automatically
-  markdown-lint:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
       - uses: xt0rted/markdownlint-problem-matcher@v2
       - uses: DavidAnson/markdownlint-cli2-action@v9
         with:
           globs: "**/*.md"
-
-  # TODO: Add problem matcher?
-  yamllint:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
       - run: yamllint -s .
 
   crev:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     # TODO: once we have enough reviews, make this a required check
     continue-on-error: true
     permissions:
@@ -125,9 +111,7 @@ jobs:
   deny:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     strategy:
       matrix:
         checks:
@@ -144,9 +128,7 @@ jobs:
   sort:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -157,9 +139,7 @@ jobs:
   clippy:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     strategy:
       matrix:
         rust:
@@ -180,9 +160,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     strategy:
       matrix:
         rust:
@@ -201,9 +179,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     strategy:
       matrix:
         rust:
@@ -222,9 +198,7 @@ jobs:
   doc:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     strategy:
       matrix:
         rust:
@@ -242,9 +216,7 @@ jobs:
   coverage:
     runs-on: ubuntu-22.04
     needs:
-      - "rustfmt"
-      - "markdown-lint"
-      - "yamllint"
+      - "lint"
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
           # - Convert the table to GHF markdown
           # - Sort descending by the "LoC" value (first column preceeds first
           #   pipe)
-
+          cargo generate-lockfile --offline
           cargo crev crate verify \
               --for-id vMr-9g5KzKQLsCpkp1tc8o7AR6a0OptjOICjf7NMyHE \
               --show-all \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
   crev:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     # TODO: once we have enough reviews, make this a required check
     continue-on-error: true
     permissions:
@@ -111,7 +111,7 @@ jobs:
   deny:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     strategy:
       matrix:
         checks:
@@ -128,7 +128,7 @@ jobs:
   sort:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -139,7 +139,7 @@ jobs:
   clippy:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     strategy:
       matrix:
         rust:
@@ -160,7 +160,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     strategy:
       matrix:
         rust:
@@ -179,7 +179,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     strategy:
       matrix:
         rust:
@@ -198,7 +198,7 @@ jobs:
   doc:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     strategy:
       matrix:
         rust:
@@ -216,7 +216,7 @@ jobs:
   coverage:
     runs-on: ubuntu-22.04
     needs:
-      - "lint"
+      - lint
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -232,9 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && failure()
     needs:
-      - rustfmt
-      - markdown-lint
-      - yamllint
+      - lint
       - deny
       - sort
       - clippy

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -16,10 +16,6 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/triage-labeler.yaml
           enable-versioned-regex: 0
-
-  add-to-project:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/add-to-project@v0.4.1
         with:
           github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -18,5 +18,5 @@ jobs:
           enable-versioned-regex: 0
       - uses: actions/add-to-project@v0.4.1
         with:
-          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
+          github-token: "${{ secrets.MEOWBLECOIN_PAT }}"
           project-url: https://github.com/orgs/mobilecoinfoundation/projects/5

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -18,4 +18,4 @@ jobs:
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "mobilecoinfoundation/coredev"
+          teams: "@mobilecoinfoundation/coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -20,4 +20,3 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           org: "mobilecoinfoundation"
           teams: "coredev"
-          pick-one-from-persons-or-team: true

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -8,8 +8,16 @@ name: pr-assign
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
           repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
           configuration-path: '.github/auto_assign.yaml'
+      - uses: rowi1de/auto-assign-review-teams@v1.1.3
+        with:
+          repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
+          org: "mobilecoinfoundation"
+          teams: "coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -17,6 +17,6 @@ jobs:
           configuration-path: '.github/auto_assign.yaml'
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.MEOWBLECOIN_TOKEN }}
           org: "mobilecoinfoundation"
           teams: "coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -9,12 +9,10 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
-          repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
           configuration-path: '.github/auto_assign.yaml'
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -17,6 +17,6 @@ jobs:
           configuration-path: '.github/auto_assign.yaml'
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
-          repo-token: ${{ secrets.MEOWBLECOIN_TOKEN }}
+          repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
           org: "mobilecoinfoundation"
           teams: "coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -17,6 +17,7 @@ jobs:
           configuration-path: '.github/auto_assign.yaml'
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           org: "mobilecoinfoundation"
           teams: "coredev"
           pick-one-from-persons-or-team: true

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -15,3 +15,8 @@ jobs:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
           configuration-path: '.github/auto_assign.yaml'
+      - uses: rowi1de/auto-assign-review-teams@v1.1.3
+        with:
+          org: "mobilecoinfoundation"
+          teams: "coredev"
+          pick-one-from-persons-or-team: true

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -13,5 +13,8 @@ jobs:
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
-          repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
           configuration-path: '.github/auto_assign.yaml'
+      - uses: rowi1de/auto-assign-review-teams@v1.1.3
+        with:
+          repo-token: ${{ secrets.MEOWBLECOIN_PAT}}
+          teams: "@mobilecoinfoundation/coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -18,4 +18,5 @@ jobs:
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@mobilecoinfoundation/coredev"
+          org: "mobilecoinfoundation"
+          teams: "coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -9,12 +9,9 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
           configuration-path: '.github/auto_assign.yaml'
-      - uses: rowi1de/auto-assign-review-teams@v1.1.3
-        with:
-          repo-token: ${{ secrets.MEOWBLECOIN_PAT}}
-          teams: "@mobilecoinfoundation/coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -13,9 +13,5 @@ jobs:
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
+          repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
           configuration-path: '.github/auto_assign.yaml'
-      - uses: rowi1de/auto-assign-review-teams@v1.1.3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "@mobilecoinfoundation/coredev"
-          persons: null

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -18,5 +18,4 @@ jobs:
       - uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          org: "mobilecoinfoundation"
-          teams: "coredev"
+          teams: "mobilecoinfoundation/coredev"

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -14,3 +14,8 @@ jobs:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
           configuration-path: '.github/auto_assign.yaml'
+      - uses: rowi1de/auto-assign-review-teams@v1.1.3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          teams: "@mobilecoinfoundation/coredev"
+          persons: null

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -8,15 +8,8 @@ name: pr-assign
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
-          configuration-path: '.github/auto_assign.yaml'
-      - uses: rowi1de/auto-assign-review-teams@v1.1.3
-        with:
           repo-token: ${{ secrets.MEOWBLECOIN_PAT }}
-          org: "mobilecoinfoundation"
-          teams: "coredev"
+          configuration-path: '.github/auto_assign.yaml'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.1
         with:
-          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
-          project-url: https://github.com/orgs/mobilecoinfoundation/projects/5
+          github-token: "${{ secrets.MEOWBLECOIN_PAT }}"
+          project-url: https://github.com/orgs/mobilecoinfoundation/projects/7
       - uses: pascalgn/size-label-action@v0.4.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,20 +5,16 @@ name: pr
   pull_request:
 
 jobs:
-  add-to-project:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v0.4.1
-        with:
-          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
-          project-url: https://github.com/orgs/mobilecoinfoundation/projects/5
-
-  size-label:
+  pr-metadata:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/add-to-project@v0.4.1
+        with:
+          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
+          project-url: https://github.com/orgs/mobilecoinfoundation/projects/5
       - uses: pascalgn/size-label-action@v0.4.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -33,13 +29,6 @@ jobs:
               "1000": "XXL",
               "1500": "OHLAWDHECOMIN"
             }
-
-  label:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
       - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- Add varsha as a maintainer
- Generate Cargo.lock to allow crev to work
- Remove the reviewer assignment from `auto-assign-action` (doesn't work)
- Add team-review assignment via PAT and `auto-assign-review-teams`
- Collapse the issue and PR metadata workflows to steps w/i a single job
- Collapse rusfmt, markdownlint, yamllint into steps within a single job
- Don't let labeller manage the `dependencies` label

### Motivation

This is about fixing some stuff that had bit-rot in our baseline CI, and reducing some (IMO) unnecessary parallelism.